### PR TITLE
run on node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -31,7 +31,7 @@ outputs:
     description: 'A full git tag string when it is used'
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'
 
 branding:


### PR DESCRIPTION
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/